### PR TITLE
sprout: restore display bring-up and re-enable Bloom compositor

### DIFF
--- a/thingos/sprout/src/pipelines.rs
+++ b/thingos/sprout/src/pipelines.rs
@@ -265,13 +265,109 @@ fn probe_bootfb_vfs() -> Option<(u32, u32, u32, u32)> {
 // Storage, Network, and Audio are now handled by cambium
 
 pub fn setup_display_pipeline(
-    _shared_tasks: Arc<Mutex<Vec<ManagedTask>>>,
-    _supervisor_port: stem::syscall::PortHandle,
-    _bind_instance_id: u64,
-    _force_bootfb: bool,
+    shared_tasks: Arc<Mutex<Vec<ManagedTask>>>,
+    supervisor_port: stem::syscall::PortHandle,
+    bind_instance_id: u64,
+    force_bootfb: bool,
 ) -> Option<DisplayHandles> {
-    info!("SPROUT: Display driver startup is disabled (network-only mode)");
-    None
+    let (width, height, stride, format) = probe_bootfb_vfs()?;
+
+    let driver_path = if force_bootfb || !file_exists("/drivers/display_virtio_gpu") {
+        "/drivers/display_bootfb"
+    } else {
+        "/drivers/display_virtio_gpu"
+    };
+
+    // Supervisor -> driver requests.
+    let (drv_req_write, drv_req_read) = match port_create(4096) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("SPROUT: Failed to create display request port: {:?}", e);
+            return None;
+        }
+    };
+
+    // Driver -> supervisor responses.
+    let (drv_resp_write, drv_resp_read) = match port_create(4096) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("SPROUT: Failed to create display response port: {:?}", e);
+            return None;
+        }
+    };
+
+    let boot_size = 4096;
+    let boot_fd = match stem::syscall::memfd_create("display.boot", boot_size) {
+        Ok(fd) => fd,
+        Err(e) => {
+            warn!("SPROUT: Failed to create display bootstrap memfd: {:?}", e);
+            return None;
+        }
+    };
+
+    use abi::vm::{VmBacking, VmMapFlags, VmMapReq, VmProt};
+    let req = VmMapReq {
+        addr_hint: 0,
+        len: boot_size,
+        prot: VmProt::READ | VmProt::WRITE | VmProt::USER,
+        flags: VmMapFlags::empty(),
+        backing: VmBacking::File { thing: boot_fd, offset: 0 },
+    };
+    let map = match stem::syscall::vm_map(&req) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!("SPROUT: Failed to map display bootstrap memfd: {:?}", e);
+            return None;
+        }
+    };
+
+    let words = unsafe { core::slice::from_raw_parts_mut(map.addr as *mut u32, boot_size / 4) };
+    words[0] = drv_req_read;
+    words[1] = drv_resp_write;
+    words[2] = supervisor_port;
+    words[3] = (bind_instance_id & 0xffff_ffff) as u32;
+    words[4] = ((bind_instance_id >> 32) & 0xffff_ffff) as u32;
+
+    info!(
+        "SPROUT: Launching display driver '{}' (boot_fd={}, bind_id={})",
+        driver_path, boot_fd, bind_instance_id
+    );
+    let pid = match stem::syscall::spawn_process(driver_path, boot_fd as usize) {
+        Ok(pid) => pid,
+        Err(e) => {
+            warn!("SPROUT: Failed to spawn display driver '{}': {:?}", driver_path, e);
+            return None;
+        }
+    };
+
+    {
+        let mut tasks = shared_tasks.lock();
+        tasks.push(ManagedTask {
+            name: "display".to_string(),
+            kind: TaskKind::Service("svc.display".to_string()),
+            module_path: driver_path.to_string(),
+            pid: Some(pid),
+            restarts: 0,
+            spawn_arg: boot_fd as usize,
+            bind_instance_id: bind_instance_id as usize,
+            drv_req_write,
+            drv_resp_read,
+            boot_req_read: 0,
+            boot_resp_write: 0,
+            resp_fd: None,
+        });
+    }
+
+    Some(DisplayHandles {
+        drv_req_write,
+        drv_resp_read,
+        bs_id: 0,
+        backend_name: if driver_path.ends_with("bootfb") { "bootfb" } else { "virtio_gpu" },
+        width,
+        height,
+        stride,
+        format,
+    })
 }
 
 pub fn setup_terminal(
@@ -562,11 +658,38 @@ pub fn setup_audio_stack(shared_tasks: Arc<Mutex<Vec<ManagedTask>>>) {
 
 pub fn setup_graphics_stack(
     shared_tasks: Arc<Mutex<Vec<ManagedTask>>>,
-    _display: Option<DisplayHandles>,
+    display: Option<DisplayHandles>,
     _input: InputHandles,
 ) {
-    let _ = shared_tasks;
-    info!("SPROUT: Bloom launch is temporarily disabled in setup_graphics_stack");
+    if display.is_none() {
+        warn!("SPROUT: Graphics stack skipped because no display handle was established");
+        return;
+    }
+
+    match stem::syscall::spawn_process("/bin/bloom", 0) {
+        Ok(pid) => {
+            info!("SPROUT: Spawned bloom (PID={})", pid);
+            let _ = stem::thread::set_priority(pid, 2);
+            let mut tasks = shared_tasks.lock();
+            tasks.push(ManagedTask {
+                name: "bloom".to_string(),
+                kind: TaskKind::Service("svc.bloom".to_string()),
+                module_path: "/bin/bloom".to_string(),
+                pid: Some(pid),
+                restarts: 0,
+                spawn_arg: 0,
+                bind_instance_id: 0,
+                drv_req_write: 0,
+                drv_resp_read: 0,
+                boot_req_read: 0,
+                boot_resp_write: 0,
+                resp_fd: None,
+            });
+        }
+        Err(e) => {
+            warn!("SPROUT: Failed to spawn bloom: {:?}", e);
+        }
+    }
 }
 
 pub fn setup_serial_shell(shared_tasks: Arc<Mutex<Vec<ManagedTask>>>) {


### PR DESCRIPTION
### Motivation
- Sprout was intentionally short-circuiting graphics bring-up (logging `Display driver startup is disabled (network-only mode)`) which caused a timeout waiting for a display and prevented the compositor from launching despite a valid boot framebuffer.
- The change aims to resume the normal display bootstrap path so the system can spawn a display driver, register it with the supervisor, and start the Bloom compositor when a display is available.

### Description
- Reworked `setup_display_pipeline` in `thingos/sprout/src/pipelines.rs` to actually initialize the display path by probing `/dev/fb0`, choosing a driver (`/drivers/display_bootfb` or `/drivers/display_virtio_gpu`), creating request/response ports, preparing a bootstrap memfd payload (request/response handles + supervisor bind id), spawning the selected display driver with the memfd, and registering the spawned driver as a `ManagedTask` in the supervisor task list.
- Updated the `setup_display_pipeline` signature to accept the supervisor context and `force_bootfb` flag and to return a populated `DisplayHandles` on success.
- Changed `setup_graphics_stack` to launch `/bin/bloom` when a `DisplayHandles` exists and to register Bloom as a managed task; added a guard and warning when no display is available.
- Kept existing terminal/bootstrap wiring but now uses the real display handles returned from `setup_display_pipeline` when available.
- Commit created with message `sprout: re-enable display pipeline and bloom launch` and the modified file is `thingos/sprout/src/pipelines.rs`.

### Testing
- Ran a repository-level build check for the `sprout` package with `cargo check -p sprout`; this failed due to the environment missing a vendored dependency file (`/workspace/thingos/vendor/crossterm/Cargo.toml`), not due to the logic change itself, so no successful compile verification could be completed in this environment.
- Performed local code inspections and searches (`rg`/file views) to confirm the new pipeline and spawn paths are wired into the supervisor flow and that `DisplayHandles` is used by downstream code; these static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e529cd3614832081c2c93e8f24c485)